### PR TITLE
Update switchbot_util.py. On Firmware 6.4 - 0x05 - Device does not support this Command

### DIFF
--- a/switchbotpy/switchbot_util.py
+++ b/switchbotpy/switchbot_util.py
@@ -13,6 +13,7 @@ def handle_notification(handle: int, value: bytes):
 class ActionStatus(Enum):
     complete = 1
     device_busy = 3
+    cmd_not_supported = 5
     device_unreachable = 11
     device_encrypted  = 7
     device_unencrypted = 8
@@ -26,6 +27,8 @@ class ActionStatus(Enum):
             msg = "action complete"
         elif self == ActionStatus.device_busy:
             msg = "switchbot is busy"
+        elif self == ActionStatus.cmd_not_supported:
+            msg = "Device does not support this Command"
         elif self == ActionStatus.device_unreachable:
             msg = "switchbot is unreachable"
         elif self == ActionStatus.device_encrypted:


### PR DESCRIPTION
My device settings:
`{'battery': 94, 'firmware': 6.4, 'n_timers': 0, 'dual_state_mode': True, 'inverse_direction': True, 'hold_seconds': 0}`

 
` File "/usr/lib/python3.11/enum.py", line 717, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/enum.py", line 1133, in __new__
    raise ve_exc
ValueError: 5 is not a valid ActionStatus`

I did a little bit of research and came across:

- 0x05 - Device does not support this Command

I want to clarify that the device works but I am seeing this error message.